### PR TITLE
Don't replace original label if no match found

### DIFF
--- a/features/custom_labels.feature
+++ b/features/custom_labels.feature
@@ -32,4 +32,4 @@ Feature: Config file allows custom labels
       """
     Then the exporter should report value 2 for metric nginx_http_response_count_total{method="GET",request_uri="/users/:id",status="200"}
     And the exporter should report value 1 for metric nginx_http_response_count_total{method="GET",request_uri="/profile",status="200"}
-    And the exporter should report value 1 for metric nginx_http_response_count_total{method="GET",request_uri="",status="200"}
+    And the exporter should report value 1 for metric nginx_http_response_count_total{method="GET",request_uri="/foo",status="200"}

--- a/features/test-configuration-labels-routes.hcl
+++ b/features/test-configuration-labels-routes.hcl
@@ -20,9 +20,5 @@ namespace "nginx" {
     match "^/profile" {
       replacement = "/profile"
     }
-
-    match {
-      replacement = ""
-    }
   }
 }

--- a/relabeling/mapping.go
+++ b/relabeling/mapping.go
@@ -24,14 +24,12 @@ func (r *Relabeling) Map(sourceValue string) (string, error) {
 	}
 
 	if len(r.Matches) > 0 {
-		replacement := ""
 		for i := range r.Matches {
 			if r.Matches[i].CompiledRegexp.MatchString(sourceValue) {
-				replacement = r.Matches[i].CompiledRegexp.ReplaceAllString(sourceValue, r.Matches[i].Replacement)
+				sourceValue = r.Matches[i].CompiledRegexp.ReplaceAllString(sourceValue, r.Matches[i].Replacement)
 				break
 			}
 		}
-		sourceValue = replacement
 	}
 
 	return sourceValue, nil

--- a/relabeling/mapping_test.go
+++ b/relabeling/mapping_test.go
@@ -50,3 +50,20 @@ func TestRequestURIMapping(t *testing.T) {
 
 	assertMapping(t, r, "GET /users/12345 HTTP/1.1", "/users/:id")
 }
+
+func TestNoMatchMapping(t *testing.T) {
+	t.Parallel()
+
+	r, err := buildRelabeling(config.RelabelConfig{
+		Split: 2,
+		Matches: []config.RelabelValueMatch{
+			{RegexpString: "^/foo", Replacement: "/bar"},
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	assertMapping(t, r, "GET /foo HTTP/1.1", "/bar")
+	assertMapping(t, r, "GET /baz HTTP/1.1", "/baz")
+}


### PR DESCRIPTION
When using relabeling, I set up a bunch of relabel rules, but those are
for exceptions. Most of the time the original value should be used.