### PR TITLE
feat: allow overwrite the default relabelings.

### DIFF
--- a/relabeling/types.go
+++ b/relabeling/types.go
@@ -24,3 +24,17 @@ func NewRelabelings(cfgs []config.RelabelConfig) []*Relabeling {
 func NewRelabeling(cfg *config.RelabelConfig) *Relabeling {
 	return &Relabeling{*cfg}
 }
+
+// UniqueRelabelings creates a unique relabelings, the duplicated one at the end will discard.
+func UniqueRelabelings(relabelings []*Relabeling) []*Relabeling {
+	result := make([]*Relabeling, 0, len(relabelings))
+	found := make(map[string]struct{})
+	for _, r := range relabelings {
+		if _, ok := found[r.TargetLabel]; ok {
+			continue
+		}
+		found[r.TargetLabel] = struct{}{}
+		result = append(result, r)
+	}
+	return result
+}


### PR DESCRIPTION
The "method" label in default relabelings may incorrect if we not use "$request"
in the nginx log_format, but already separated to "$request_method" and
"$request_uri", allow user to overwrite default relabelings to fix it.