### PR TITLE
Add all existed HTTP methods to whitelist for label method

### DIFF
--- a/relabeling/defaults.go
+++ b/relabeling/defaults.go
@@ -4,31 +4,43 @@ import "github.com/martin-helmich/prometheus-nginxlog-exporter/config"
 
 // DefaultRelabelings are hardcoded relabeling configs that are always there
 // and do not need to be explicitly configured
-var DefaultRelabelings = []*Relabeling{
-	{
-		config.RelabelConfig{
-			TargetLabel: "method",
-			SourceValue: "request",
-			Split:       1,
 
-			WhitelistExists: true,
-			Whitelist: []string{
-				"GET",
-				"HEAD",
-				"POST",
-				"PUT",
-				"DELETE",
-				"CONNECT",
-				"OPTIONS",
-				"TRACE",
-				"PATCH",
-			},
-		},
-	},
-	{
-		config.RelabelConfig{
-			TargetLabel: "status",
-			SourceValue: "status",
-		},
-	},
+func createMethodWhitelistMap() map[string]interface{} {
+        whitelistMap := make(map[string]interface{})
+        whitelist := []string{
+                "HEAD",
+                "POST",
+                "GET",
+                "PUT",
+                "DELETE",
+                "CONNECT",
+                "OPTIONS",
+                "TRACE",
+                "PATCH",
+        }
+
+        for i := range whitelist {
+                whitelistMap[whitelist[i]] = nil
+        }
+
+        return whitelistMap
+}
+
+var DefaultRelabelings = []*Relabeling{
+        {
+                config.RelabelConfig{
+                        TargetLabel: "method",
+                        SourceValue: "request",
+                        Split:       1,
+
+                        WhitelistExists: true,
+                        WhitelistMap:    createMethodWhitelistMap(),
+                },
+        },
+        {
+                config.RelabelConfig{
+                        TargetLabel: "status",
+                        SourceValue: "status",
+                },
+        },
 }

--- a/relabeling/defaults.go
+++ b/relabeling/defaults.go
@@ -4,32 +4,31 @@ import "github.com/martin-helmich/prometheus-nginxlog-exporter/config"
 
 // DefaultRelabelings are hardcoded relabeling configs that are always there
 // and do not need to be explicitly configured
-
 var DefaultRelabelings = []*Relabeling{
-        {
-                config.RelabelConfig{
-                        TargetLabel: "method",
-                        SourceValue: "request",
-                        Split:       1,
+	{
+		config.RelabelConfig{
+			TargetLabel: "method",
+			SourceValue: "request",
+			Split:       1,
 
-                        WhitelistExists: true,
-                        WhitelistMap: map[string]interface{}{
-                                "CONNECT": nil,
-                                "DELETE":  nil,
-                                "GET":     nil,
-                                "HEAD":    nil,
-                                "OPTIONS": nil,
-                                "PATCH":   nil,
-                                "POST":    nil,
-                                "PUT":     nil,
-                                "TRACE":   nil,
-                        },
-                },
-        },
-        {
-                config.RelabelConfig{
-                        TargetLabel: "status",
-                        SourceValue: "status",
-                },
-        },
+			WhitelistExists: true,
+			WhitelistMap: map[string]interface{}{
+				"GET":     nil,
+				"HEAD":    nil,
+				"POST":    nil,
+				"PUT":     nil,
+				"DELETE":  nil,
+				"CONNECT": nil,
+				"OPTIONS": nil,
+				"TRACE":   nil,
+				"PATCH":   nil,
+			},
+		},
+	},
+	{
+		config.RelabelConfig{
+			TargetLabel: "status",
+			SourceValue: "status",
+		},
+	},
 }

--- a/relabeling/defaults.go
+++ b/relabeling/defaults.go
@@ -12,7 +12,7 @@ var DefaultRelabelings = []*Relabeling{
 			Split:       1,
 
 			WhitelistExists: true,
-			WhitelistMap: []string{
+			Whitelist: []string{
 				"GET",
 				"HEAD",
 				"POST",

--- a/relabeling/defaults.go
+++ b/relabeling/defaults.go
@@ -5,27 +5,6 @@ import "github.com/martin-helmich/prometheus-nginxlog-exporter/config"
 // DefaultRelabelings are hardcoded relabeling configs that are always there
 // and do not need to be explicitly configured
 
-func createMethodWhitelistMap() map[string]interface{} {
-        whitelistMap := make(map[string]interface{})
-        whitelist := []string{
-                "HEAD",
-                "POST",
-                "GET",
-                "PUT",
-                "DELETE",
-                "CONNECT",
-                "OPTIONS",
-                "TRACE",
-                "PATCH",
-        }
-
-        for i := range whitelist {
-                whitelistMap[whitelist[i]] = nil
-        }
-
-        return whitelistMap
-}
-
 var DefaultRelabelings = []*Relabeling{
         {
                 config.RelabelConfig{
@@ -34,7 +13,17 @@ var DefaultRelabelings = []*Relabeling{
                         Split:       1,
 
                         WhitelistExists: true,
-                        WhitelistMap:    createMethodWhitelistMap(),
+                        WhitelistMap: map[string]interface{}{
+                                "CONNECT": nil,
+                                "DELETE":  nil,
+                                "GET":     nil,
+                                "HEAD":    nil,
+                                "OPTIONS": nil,
+                                "PATCH":   nil,
+                                "POST":    nil,
+                                "PUT":     nil,
+                                "TRACE":   nil,
+                        },
                 },
         },
         {

--- a/relabeling/defaults.go
+++ b/relabeling/defaults.go
@@ -10,6 +10,19 @@ var DefaultRelabelings = []*Relabeling{
 			TargetLabel: "method",
 			SourceValue: "request",
 			Split:       1,
+
+			WhitelistExists: true,
+			WhitelistMap: []string{
+				"GET",
+				"HEAD",
+				"POST",
+				"PUT",
+				"DELETE",
+				"CONNECT",
+				"OPTIONS",
+				"TRACE",
+				"PATCH",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Some sort of spammers use nonexisted HTTP methods. So this creates a lot of entities in prometheus.

