### PR TITLE
syslog follower.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,9 +92,11 @@ consul {
 
 namespace "app1" {
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
-  source_files = [
-    "/var/log/nginx/app1/access.log"
-  ]
+  source_data {
+    files = [
+      "/var/log/nginx/app1/access.log"
+    ]
+  }
   labels {
     app = "application-one"
     environment = "production"
@@ -106,9 +108,11 @@ namespace "app1" {
 
 namespace "app2" {
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\" $upstream_response_time"
-  source_files = [
-    "/var/log/nginx/app2/access.log"
-  ]
+  source_data  {
+    files = [
+      "/var/log/nginx/app2/access.log"
+    ]
+  }
 }
 ----
 
@@ -134,8 +138,9 @@ consul:
 namespaces:
   - name: app1
     format: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
-    source_files:
-      - /var/log/nginx/app1/access.log
+    source_data:
+      files:
+        - /var/log/nginx/app1/access.log
     labels:
       app: "application-one"
       environment: "production"
@@ -143,8 +148,9 @@ namespaces:
     histogram_buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
   - name: app2
     format: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\" $upstream_response_time"
-    source_files:
-      - /var/log/nginx/app2/access.log
+    source_data:
+      files:
+        - /var/log/nginx/app2/access.log
 ----
 
 Experimental features

--- a/config/loader_flags.go
+++ b/config/loader_flags.go
@@ -9,9 +9,11 @@ func LoadConfigFromFlags(config *Config, flags *StartupFlags) error {
 	}
 	config.Namespaces = []NamespaceConfig{
 		{
-			Format:      flags.Format,
-			SourceFiles: flags.Filenames,
-			Name:        flags.Namespace,
+			Format: flags.Format,
+			Name:   flags.Namespace,
+			SourceData: &SourceData{
+				Files: flags.Filenames,
+			},
 		},
 	}
 

--- a/config/loader_flags_test.go
+++ b/config/loader_flags_test.go
@@ -41,7 +41,7 @@ func TestConfigContainsFilenamesFromFlags(t *testing.T) {
 		t.Error("unexpected namespace count", "expected", 1, "actual", len(cfg.Namespaces))
 	}
 
-	if !reflect.DeepEqual(cfg.Namespaces[0].SourceFiles, sf) {
-		t.Error("unexpected source files", "expected", sf, "actual", cfg.Namespaces[0].SourceFiles)
+	if !reflect.DeepEqual(cfg.Namespaces[0].SourceData.Files, sf) {
+		t.Error("unexpected source files", "expected", sf, "actual", cfg.Namespaces[0].SourceData.Files)
 	}
 }

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -29,10 +29,12 @@ consul {
 }
 
 namespace "nginx" {
-  source_files = [
-    "test.log",
-    "foo.log"
-  ]
+  source_data = {
+	files = [
+      "test.log",
+      "foo.log"
+    ]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
 
   labels {
@@ -80,9 +82,10 @@ consul:
 
 namespaces:
   - name: nginx
-    source_files:
-      - test.log
-      - foo.log
+    source_data:
+      files:
+        - test.log
+        - foo.log
     format: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
     labels:
       app: "magicapp"
@@ -119,7 +122,7 @@ func assertConfigContents(t *testing.T, cfg Config) {
 	n := cfg.Namespaces[0]
 	assert.Equal(t, "nginx", n.Name)
 	assert.Equal(t, "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\"", n.Format)
-	assert.Equal(t, []string{"test.log", "foo.log"}, n.SourceFiles)
+	assert.Equal(t, []string{"test.log", "foo.log"}, n.SourceData.Files)
 	assert.Equal(t, "magicapp", n.Labels["app"])
 
 	require.Len(t, n.RelabelConfigs, 2)

--- a/config/struct_namespace.go
+++ b/config/struct_namespace.go
@@ -8,7 +8,7 @@ import (
 // NamespaceConfig is a struct describing single metric namespaces
 type NamespaceConfig struct {
 	Name             string            `hcl:",key"`
-	SourceFiles      []string          `hcl:"source_files" yaml:"source_files"`
+	SourceData       *SourceData       `hcl:"source_data" yaml:"source_data"`
 	Format           string            `hcl:"format"`
 	Labels           map[string]string `hcl:"labels"`
 	RelabelConfigs   []RelabelConfig   `hcl:"relabel" yaml:"relabel_configs"`
@@ -16,6 +16,11 @@ type NamespaceConfig struct {
 
 	OrderedLabelNames  []string
 	OrderedLabelValues []string
+}
+
+type SourceData struct {
+	Files      []string `hcl:"files" yaml:"files"`
+	SyslogTags []string `hcl:"syslog_tags" yaml:"syslog_tags"`
 }
 
 // StabilityWarnings tests if the NamespaceConfig uses any configuration settings

--- a/config/structs.go
+++ b/config/structs.go
@@ -31,6 +31,7 @@ type Config struct {
 type ListenConfig struct {
 	Port    int
 	Address string
+	Syslog  string
 }
 
 // ConsulConfig describes the connection to a Consul server that the exporter should

--- a/example-config.hcl
+++ b/example-config.hcl
@@ -1,5 +1,6 @@
 listen {
   port = 4040
+  syslog = "upd://0.0.0.0:5531"
 }
 
 consul {
@@ -16,10 +17,16 @@ consul {
 }
 
 namespace "nginx" {
-  source_files = [
-    "test.log",
-    "foo.log"
-  ]
+  source_data = {
+    files = [
+      "test.log",
+      "foo.log",
+    ],
+    syslog_tags = [
+      "sometag"
+    ]
+  }
+
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
 
   labels {

--- a/features/test-config-issue44.yaml
+++ b/features/test-config-issue44.yaml
@@ -6,5 +6,6 @@ listen:
 namespaces:
   - name: ht_router
     format: "$time_iso8601\t$geoip_country_code\t$remote_addr\t$scheme\t$host\t$request_method\t\"$request_uri\"\t$status\t$body_bytes_sent\t\"$http_referer\"\t\"$http_user_agent\"\t-\t$request_time\t$upstream_response_time"
-    source_files:
-      - .behave-sandbox/access.log
+    source_data:
+      files:
+        - .behave-sandbox/access.log

--- a/features/test-configuration-labels-multi.hcl
+++ b/features/test-configuration-labels-multi.hcl
@@ -1,7 +1,9 @@
 port = 4040
 
 namespace "testone" {
-  source_files = [".behave-sandbox/access.log"]
+  source_data {
+    files = [".behave-sandbox/access.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   labels {
     test1 = "1-1"
@@ -10,7 +12,9 @@ namespace "testone" {
 }
 
 namespace "testtwo" {
-  source_files = [".behave-sandbox/access-two.log"]
+  source_data {
+    files = [".behave-sandbox/access-two.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   labels {
     test1 = "2-1"
@@ -20,7 +24,9 @@ namespace "testtwo" {
 
 
 namespace "testthree" {
-  source_files = [".behave-sandbox/access-three.log"]
+  source_data {
+    files = [".behave-sandbox/access-three.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   labels {
     test1 = "3-1"
@@ -30,7 +36,9 @@ namespace "testthree" {
 
 
 namespace "testfour" {
-  source_files = [".behave-sandbox/access-four.log"]
+  source_data {
+    files = [".behave-sandbox/access-four.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   labels {
     test1 = "4-1"
@@ -40,7 +48,9 @@ namespace "testfour" {
 
 
 namespace "testfive" {
-  source_files = [".behave-sandbox/access-five.log"]
+  source_data {
+    files = [".behave-sandbox/access-five.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   labels {
     test1 = "5-1"

--- a/features/test-configuration-labels-routes.hcl
+++ b/features/test-configuration-labels-routes.hcl
@@ -2,7 +2,9 @@ port = 4040
 enable_experimental = true
 
 namespace "nginx" {
-  source_files = [".behave-sandbox/access.log"]
+  source_data {
+    files = [".behave-sandbox/access.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   #routes = [
   #  "^/users/[0-9]+",

--- a/features/test-configuration-labels.hcl
+++ b/features/test-configuration-labels.hcl
@@ -1,7 +1,9 @@
 port = 4040
 
 namespace "nginx" {
-  source_files = [".behave-sandbox/access.log"]
+  source_data {
+    files = [".behave-sandbox/access.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   labels {
     foo = "bar"

--- a/features/test-configuration-relabel.hcl
+++ b/features/test-configuration-relabel.hcl
@@ -2,7 +2,9 @@ port = 4040
 enable_experimental = true
 
 namespace "nginx" {
-  source_files = [".behave-sandbox/access.log"]
+  source_data {
+    files = [".behave-sandbox/access.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
 
   relabel "user" {

--- a/features/test-configuration.hcl
+++ b/features/test-configuration.hcl
@@ -1,13 +1,17 @@
 port = 4040
 
 namespace "nginx" {
-  source_files = [".behave-sandbox/access-1.log"]
+  source_data {
+    files = [".behave-sandbox/access-1.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
   
   histogram_buckets = [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
 }
 
 namespace "apache" {
-  source_files = [".behave-sandbox/access-2.log"]
+  source_data {
+    files = [".behave-sandbox/access-2.log"]
+  }
   format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
 }

--- a/features/test-configuration.yaml
+++ b/features/test-configuration.yaml
@@ -3,11 +3,13 @@ listen:
 
 namespaces:
   - name: nginx
-    source_files:
-      - .behave-sandbox/access-1.log
+    source_data:
+      files:
+        - .behave-sandbox/access-1.log
     format: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""
     histogram_buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
   - name: apache
-    source_files:
-      - .behave-sandbox/access-2.log
+    source_data:
+      files:
+        - .behave-sandbox/access-2.log
     format: "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,9 @@ require (
 	golang.org/x/sys v0.0.0-20161023150541-c200b10b5d5e // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/mcuadros/go-syslog.v2 v2.3.0
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 )
+
+go 1.13

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -1,0 +1,59 @@
+package syslog
+
+import (
+	"fmt"
+	"gopkg.in/mcuadros/go-syslog.v2"
+	"net/url"
+)
+
+func openListener(s *syslog.Server, c string) error {
+	u, err := url.Parse(c)
+	if err != nil {
+		return err
+	}
+
+	switch u.Scheme {
+	case "tcp":
+		err := s.ListenTCP(u.Host)
+		if err != nil {
+			return err
+		}
+
+	case "udp":
+		err := s.ListenUDP(u.Host)
+		if err != nil {
+			return err
+		}
+
+	case "unix":
+		return fmt.Errorf("Not implemented")
+
+	default:
+		return fmt.Errorf("syslog server should be in format unix/tcp/udp://127.0.0.1:5533")
+	}
+
+	return nil
+}
+
+func SyslogRunner(conn string) (syslog.LogPartsChannel, error) {
+	channel := make(syslog.LogPartsChannel)
+	handler := syslog.NewChannelHandler(channel)
+
+	server := syslog.NewServer()
+
+	//RFC3164 or RFC5424 or RFC6587. nginx works on RFC3164
+	server.SetFormat(syslog.RFC3164)
+	server.SetHandler(handler)
+
+	err := openListener(server, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	err = server.Boot()
+	if err != nil {
+		return nil, err
+	}
+
+	return channel, nil
+}

--- a/tail/struct.go
+++ b/tail/struct.go
@@ -1,0 +1,7 @@
+package tail
+
+// Follower describes an object that continuously emits a stream of lines
+type Follower interface {
+	Lines() chan string
+	OnError(func(error))
+}

--- a/tail/syslog.go
+++ b/tail/syslog.go
@@ -1,0 +1,46 @@
+package tail
+
+import (
+	"gopkg.in/mcuadros/go-syslog.v2"
+)
+
+type syslogFollower struct {
+	tag  string
+	line chan string
+
+	channel syslog.LogPartsChannel
+	server  syslog.Server
+}
+
+func NewSyslogFollower(tag string, channel syslog.LogPartsChannel) (Follower, error) {
+	s := &syslogFollower{
+		tag:     tag,
+		channel: channel,
+		line:    make(chan string),
+	}
+	return s, nil
+}
+
+func (s *syslogFollower) OnError(cb func(error)) {
+	go func() {
+		err := s.server.GetLastError()
+		if err != nil {
+			cb(err)
+		}
+	}()
+}
+
+func (s *syslogFollower) Lines() chan string {
+	go func() {
+		for line := range s.channel {
+			if _, ok := line["tag"].(string); !ok {
+				continue
+			}
+
+			if line["tag"].(string) == s.tag {
+				s.line <- line["content"].(string)
+			}
+		}
+	}()
+	return s.line
+}


### PR DESCRIPTION
The main idea:  Add syslog server and capture log messages according tags
Example configs:

nginx.conf
```
access_log syslog:server=127.0.0.1:5531,tag=nginxtag main;
```

config.hcl
```hcl
listen {
  port = 4040
  syslog = "udp://0.0.0.0:5531"
}

namespace "nginx" {
  source_data = {
    files = [
      "test.log",
    ],
    syslog_tags = [
      "nginxtag"
    ]
  }

  format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\""

  labels {
    app = "magicapp"
    foo = "bar"
  }

  histogram_buckets = [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]

  relabel "request_uri" {
    from = "request"
    split = 2

    match "^users/[0-9]+" {
      replacement = "/users/:id"
    }
  }
}
```