### PR TITLE
replace whole value instead of only matches for relabeling

### DIFF
--- a/relabeling/mapping.go
+++ b/relabeling/mapping.go
@@ -29,7 +29,9 @@ func (r *Relabeling) Map(sourceValue string) (string, error) {
 		replacement := ""
 		for i := range r.Matches {
 			if r.Matches[i].CompiledRegexp.MatchString(sourceValue) {
-				replacement = r.Matches[i].CompiledRegexp.ReplaceAllString(sourceValue, r.Matches[i].Replacement)
+				replacement = r.Matches[i].CompiledRegexp.ReplaceAllString(
+					r.Matches[i].CompiledRegexp.FindString(sourceValue),
+					r.Matches[i].Replacement)
 				break
 			}
 		}

--- a/relabeling/mapping_test.go
+++ b/relabeling/mapping_test.go
@@ -49,4 +49,21 @@ func TestRequestURIMapping(t *testing.T) {
 	}
 
 	assertMapping(t, r, "GET /users/12345 HTTP/1.1", "/users/:id")
+	assertMapping(t, r, "GET /users/12345/about HTTP/1.1", "/users/:id")
+}
+
+func TestAgentMapping(t *testing.T) {
+	t.Parallel()
+
+	r, err := buildRelabeling(config.RelabelConfig{
+		Split: 0,
+		Matches: []config.RelabelValueMatch{
+			{RegexpString: "(Firefox)/(\\d+)\\.(\\d+)(pre|[ab]\\d+[a-z]*|)", Replacement: "$1"},
+		},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	assertMapping(t, r, "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:74.0) Gecko/20100101 Firefox/74.0", "Firefox")
 }


### PR DESCRIPTION
Change the behavior for the dynamic relabeling so that for a match the whole value is replaced by the replacement instead of the matches within the value being replaced by the replacement.

This way it is possible to use regular expressions for matching that don't cover the whole value but still replace it completely.

I was a bit surprised going by the examples in the README that the behavior was to replace the matches in the value instead of the whole value. Especially since I would guess the usual use case is to reduce the number of different values for a label.

So I hope that this change is in line with your intentions for the behavior of the relabeling and can serve as a fix.

Otherwise, maybe it would make sense to make the changed behavior based on a configuration option?