### PR TITLE
Add relabeling setting to add label only to response count metric

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -492,6 +492,9 @@ namespace "app1" {
     from = "request"
     split = 2
 
+    // if enabled, only include label in response count metric (default is false)
+    only_counter = false
+
     match "^/users/[0-9]+" {
       replacement = "/users/:id"
     }

--- a/config/struct_namespace.go
+++ b/config/struct_namespace.go
@@ -28,6 +28,8 @@ type NamespaceConfig struct {
 
 	OrderedLabelNames  []string
 	OrderedLabelValues []string
+
+	HasCounterOnlyLabels bool
 }
 
 type SourceData struct {

--- a/config/struct_relabel.go
+++ b/config/struct_relabel.go
@@ -13,6 +13,7 @@ type RelabelConfig struct {
 	Whitelist   []string            `hcl:"whitelist"`
 	Matches     []RelabelValueMatch `hcl:"match"`
 	Split       int                 `hcl:"split"`
+	OnlyCounter bool                `hcl:"only_counter" yaml:"only_counter"`
 
 	WhitelistExists bool
 	WhitelistMap    map[string]interface{}

--- a/example-config.hcl
+++ b/example-config.hcl
@@ -49,6 +49,8 @@ namespace "nginx" {
   relabel "user" {
     from = "remote_user"
     // whitelist = ["-", "user1", "user2"]
+
+    only_counter = true
   }
 
   relabel "request_uri" {

--- a/features/only_counter_relabel.feature
+++ b/features/only_counter_relabel.feature
@@ -1,0 +1,37 @@
+Feature: Config file allows relabeling that only apply to the request counter
+
+  Scenario: Labels are added request counter
+    Given a running exporter listening with configuration file "test-configuration-only-counter-relabel.hcl"
+    When the following HTTP request is logged to "access.log"
+      """
+      172.17.0.1 - - [23/Jun/2016:16:04:20 +0000] "GET /users HTTP/1.1" 200 612 "-" "curl/7.29.0" "-" 10 10
+      172.17.0.1 - foo [23/Jun/2016:16:04:20 +0000] "GET /groups HTTP/1.1" 200 518 "-" "curl/7.29.0" "-" 10 10
+      """
+    Then the exporter should report value 1 for metric nginx_http_response_count_total{method="GET",path="/groups",status="200",user="foo"}
+    And the exporter should report value 1 for metric nginx_http_response_count_total{method="GET",path="/users",status="200",user="other"}
+
+  Scenario: Labels are not add added to size counter
+    Given a running exporter listening with configuration file "test-configuration-only-counter-relabel.hcl"
+    When the following HTTP request is logged to "access.log"
+      """
+      172.17.0.1 - - [23/Jun/2016:16:04:20 +0000] "GET /users HTTP/1.1" 200 612 "-" "curl/7.29.0" "-" 10 10
+      172.17.0.1 - foo [23/Jun/2016:16:04:20 +0000] "GET /groups HTTP/1.1" 200 518 "-" "curl/7.29.0" "-" 10 10
+      """
+    Then the exporter should report value 518 for metric nginx_http_response_size_bytes{method="GET",status="200",user="foo"}
+    And the exporter should report value 612 for metric nginx_http_response_size_bytes{method="GET",status="200",user="other"}
+
+  Scenario: Labels are not add added to histograms or summaries
+    Given a running exporter listening with configuration file "test-configuration-only-counter-relabel.hcl"
+    When the following HTTP request is logged to "access.log"
+      """
+      172.17.0.1 - - [23/Jun/2016:16:04:20 +0000] "GET /users HTTP/1.1" 200 612 "-" "curl/7.29.0" "-" 10 10
+      172.17.0.1 - foo [23/Jun/2016:16:04:20 +0000] "GET /groups HTTP/1.1" 200 518 "-" "curl/7.29.0" "-" 10 10
+      """
+    Then the exporter should report value 1 for metric nginx_http_upstream_time_seconds_hist_count{method="GET",status="200",user="foo"}
+    And the exporter should report value 1 for metric nginx_http_upstream_time_seconds_hist_count{method="GET",status="200",user="other"}
+    And the exporter should report value 1 for metric nginx_http_upstream_time_seconds_count{method="GET",status="200",user="foo"}
+    And the exporter should report value 1 for metric nginx_http_upstream_time_seconds_count{method="GET",status="200",user="other"}
+    And the exporter should report value 1 for metric nginx_http_response_time_seconds_hist_count{method="GET",status="200",user="foo"}
+    And the exporter should report value 1 for metric nginx_http_response_time_seconds_hist_count{method="GET",status="200",user="other"}
+    And the exporter should report value 1 for metric nginx_http_response_time_seconds_count{method="GET",status="200",user="foo"}
+    And the exporter should report value 1 for metric nginx_http_response_time_seconds_count{method="GET",status="200",user="other"}

--- a/features/test-configuration-only-counter-relabel.hcl
+++ b/features/test-configuration-only-counter-relabel.hcl
@@ -1,0 +1,21 @@
+port = 4040
+enable_experimental = true
+
+namespace "nginx" {
+  source {
+    files = [".behave-sandbox/access.log"]
+  }
+  format = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" \"$http_x_forwarded_for\" $request_time $upstream_response_time"
+
+  relabel "user" {
+    from = "remote_user"
+    whitelist = ["foo", "bar"]
+  }
+
+  relabel "path" {
+    from = "request"
+    split = 2
+
+    only_counter = true
+  }
+}

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -106,6 +107,7 @@ github.com/prometheus/common v0.0.0-20160623151427-4402f4e5ea79/go.mod h1:daVV7q
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
+github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9 h1:ex32PG6WhE5zviWS08vcXTwX2IkaH9zpeYZZvrmj3/U=
 github.com/prometheus/procfs v0.0.0-20160411190841-abf152e5f3e9/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -115,6 +117,7 @@ github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLk
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/satyrius/gonx v1.3.1-0.20180709120835-47c52b995fe5 h1:nIAK+9DnhpSebWeiIqvPr0rqSDC3j9r1I2bp0OJAYVE=
 github.com/satyrius/gonx v1.3.1-0.20180709120835-47c52b995fe5/go.mod h1:+r8KNe5d2tjkZU+DfhERo0G6KxkGih+1qYF6tqLHwvk=
@@ -166,6 +169,7 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfru
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -182,6 +186,7 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -87,14 +87,21 @@ func (m *Metrics) Init(cfg *config.NamespaceConfig) {
 	cfg.MustCompile()
 
 	labels := cfg.OrderedLabelNames
+	counterLabels := labels
 
 	for i := range cfg.RelabelConfigs {
-		labels = append(labels, cfg.RelabelConfigs[i].TargetLabel)
+		if !cfg.RelabelConfigs[i].OnlyCounter {
+			labels = append(labels, cfg.RelabelConfigs[i].TargetLabel)
+		}
+		counterLabels = append(counterLabels, cfg.RelabelConfigs[i].TargetLabel)
 	}
 
 	for _, r := range relabeling.DefaultRelabelings {
 		if !inLabels(r.TargetLabel, labels) {
 			labels = append(labels, r.TargetLabel)
+		}
+		if !inLabels(r.TargetLabel, counterLabels) {
+			counterLabels = append(counterLabels, r.TargetLabel)
 		}
 	}
 
@@ -103,7 +110,7 @@ func (m *Metrics) Init(cfg *config.NamespaceConfig) {
 		ConstLabels: cfg.NamespaceLabels,
 		Name:        "http_response_count_total",
 		Help:        "Amount of processed HTTP requests",
-	}, labels)
+	}, counterLabels)
 
 	m.bytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   cfg.NamespacePrefix,
@@ -317,6 +324,14 @@ func processNamespace(nsCfg config.NamespaceConfig, metrics *Metrics) {
 		}
 	}
 
+	// determine once if there are any relabeling configurations for only the response counter
+	for _, r := range nsCfg.RelabelConfigs {
+		if r.OnlyCounter {
+			nsCfg.HasCounterOnlyLabels = true
+			break
+		}
+	}
+
 	for _, f := range followers {
 		go processSource(nsCfg, f, parser, metrics)
 	}
@@ -361,20 +376,27 @@ func processSource(nsCfg config.NamespaceConfig, t tail.Follower, parser *gonx.P
 			}
 		}
 
+		var notCounterValues []string
+		if nsCfg.HasCounterOnlyLabels {
+			notCounterValues = relabeling.StripOnlyCounterValues(labelValues, relabelings)
+		} else {
+			notCounterValues = labelValues
+		}
+
 		metrics.countTotal.WithLabelValues(labelValues...).Inc()
 
 		if bytes, ok := floatFromFields(fields, "body_bytes_sent"); ok {
-			metrics.bytesTotal.WithLabelValues(labelValues...).Add(bytes)
+			metrics.bytesTotal.WithLabelValues(notCounterValues...).Add(bytes)
 		}
 
 		if upstreamTime, ok := floatFromFields(fields, "upstream_response_time"); ok {
-			metrics.upstreamSeconds.WithLabelValues(labelValues...).Observe(upstreamTime)
-			metrics.upstreamSecondsHist.WithLabelValues(labelValues...).Observe(upstreamTime)
+			metrics.upstreamSeconds.WithLabelValues(notCounterValues...).Observe(upstreamTime)
+			metrics.upstreamSecondsHist.WithLabelValues(notCounterValues...).Observe(upstreamTime)
 		}
 
 		if responseTime, ok := floatFromFields(fields, "request_time"); ok {
-			metrics.responseSeconds.WithLabelValues(labelValues...).Observe(responseTime)
-			metrics.responseSecondsHist.WithLabelValues(labelValues...).Observe(responseTime)
+			metrics.responseSeconds.WithLabelValues(notCounterValues...).Observe(responseTime)
+			metrics.responseSecondsHist.WithLabelValues(notCounterValues...).Observe(responseTime)
 		}
 	}
 }

--- a/relabeling/types.go
+++ b/relabeling/types.go
@@ -38,3 +38,17 @@ func UniqueRelabelings(relabelings []*Relabeling) []*Relabeling {
 	}
 	return result
 }
+
+// StripOnlyCounterValues strips all values that are associated to relabelings only intended for the request counter
+func StripOnlyCounterValues(values []string, relabelings []*Relabeling) []string {
+	result := make([]string, 0, len(values))
+	offset := len(values) - len(relabelings)
+	for i := range values {
+		if i >= offset && relabelings[i-offset].OnlyCounter {
+			// skip if relabeling and only enabled for counter
+			continue
+		}
+		result = append(result, values[i])
+	}
+	return result
+}


### PR DESCRIPTION
Dynamic relabeling can potentially result in a lot of time series being collected, especially related to the response and upstreams time histograms.
This change is intended to allow collecting more detailed information on response count without the side effect of adding more dimensions to the other metrics.

I hope this is something that you may find useful. Basically my first time writing any Go code, so you are very welcome to propose improvements to the code.