### PR TITLE
Add maintainer to DEB package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ nfpms:
     homepage: https://github.com/martin-helmich/prometheus-nginxlog-exporter
     description: Export Prometheus metrics from NGINX (or compatible) log files
     license: Apache 2.0
+    maintainer: Martin Helmich <martin@helmich.me>
     formats:
       - deb
       - rpm


### PR DESCRIPTION
This fixes the "missing maintainer" warnings when installing the
exporter from the DEB package.

Fixes #138