### PR TITLE
Add JSON parser to support JSON log files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.15
 
 COPY . /work
 WORKDIR /work

--- a/config/struct_namespace.go
+++ b/config/struct_namespace.go
@@ -19,8 +19,9 @@ type NamespaceConfig struct {
 
 	SourceFiles      []string          `hcl:"source_files" yaml:"source_files"`
 	SourceData       SourceData        `hcl:"source" yaml:"source"`
-	Format           string            `hcl:"format"`
-	Labels           map[string]string `hcl:"labels"`
+	Parser           string            `hcl:"parser" yaml:"parser"`
+	Format           string            `hcl:"format" yaml:"format"`
+	Labels           map[string]string `hcl:"labels" yaml:"labels"`
 	RelabelConfigs   []RelabelConfig   `hcl:"relabel" yaml:"relabel_configs"`
 	HistogramBuckets []float64         `hcl:"histogram_buckets" yaml:"histogram_buckets"`
 

--- a/config/structs.go
+++ b/config/structs.go
@@ -5,6 +5,7 @@ package config
 type StartupFlags struct {
 	ConfigFile                 string
 	Filenames                  []string
+	Parser                     string
 	Format                     string
 	Namespace                  string
 	ListenPort                 int

--- a/parser/jsonparser/jsonparser.go
+++ b/parser/jsonparser/jsonparser.go
@@ -1,0 +1,30 @@
+package jsonparser
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JsonParser parses a JSON string.
+type JsonParser struct{}
+
+// JsonParser returns a new json parser.
+func NewJsonParser() *JsonParser {
+	return &JsonParser{}
+}
+
+// ParseString implements the Parser interface.
+// The value in the map is not necessarily a string, so it needs to be converted.
+func (j *JsonParser) ParseString(line string) (map[string]string, error) {
+	var parsed map[string]interface{}
+	err := json.Unmarshal([]byte(line), &parsed)
+	if err != nil {
+		return nil, fmt.Errorf("json log parsing err: %w", err)
+	}
+
+	fields := make(map[string]string, len(parsed))
+	for k, v := range parsed {
+		fields[k] = fmt.Sprintf("%v", v)
+	}
+	return fields, nil
+}

--- a/parser/jsonparser/jsonparser_test.go
+++ b/parser/jsonparser/jsonparser_test.go
@@ -1,0 +1,44 @@
+package jsonparser
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestJsonParse(t *testing.T) {
+	parser := NewJsonParser()
+	line := `{"time_local":"2021-02-03T09:58:57+08:00","request_length":123,"request_method":"GET","request":"GET /gateway/worksheet/worksheet/getWorksheetById?id=16523 HTTP/1.1","body_bytes_sent":519,"status": 200,"request_time":0.544,"upstream_response_time":"0.543"}`
+
+	got, err := parser.ParseString(line)
+	if err != nil {
+		t.Error(err)
+	}
+	want := map[string]string{
+		"time_local":             "2021-02-03T09:58:57+08:00",
+		"request_time":           "0.544",
+		"request_length":         "123",
+		"upstream_response_time": "0.543",
+		"status":                 "200",
+		"body_bytes_sent":        "519",
+		"request":                "GET /gateway/worksheet/worksheet/getWorksheetById?id=16523 HTTP/1.1",
+		"request_method":         "GET",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("JsonParser.Parse() = %v, want %v", got, want)
+	}
+}
+
+func BenchmarkParseJson(b *testing.B) {
+	parser := NewJsonParser()
+	line := `{"time_local":"2021-02-03T09:58:57+08:00","request_length":123,"request_method":"GET","request":"GET /gateway/worksheet/worksheet/getWorksheetById?id=16523 HTTP/1.1","body_bytes_sent":519,"status": 200,"request_time":0.544,"upstream_response_time":"0.543"}`
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := parser.ParseString(line)
+		if err != nil {
+			b.Error(err)
+		}
+		_ = fmt.Sprintf("%v", res)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,24 @@
+package parser
+
+import (
+	"github.com/martin-helmich/prometheus-nginxlog-exporter/config"
+	"github.com/martin-helmich/prometheus-nginxlog-exporter/parser/jsonparser"
+	"github.com/martin-helmich/prometheus-nginxlog-exporter/parser/textparser"
+)
+
+// Parser parses a line of log as a map[string]string.
+type Parser interface {
+	ParseString(line string) (map[string]string, error)
+}
+
+// NewParser returns a Parser with the given config.NamespaceConfig.
+func NewParser(nsCfg config.NamespaceConfig) Parser {
+	switch nsCfg.Parser {
+	case "text":
+		return textparser.NewTextParser(nsCfg.Format)
+	case "json":
+		return jsonparser.NewJsonParser()
+	default:
+		return textparser.NewTextParser(nsCfg.Format)
+	}
+}

--- a/parser/textparser/textparser.go
+++ b/parser/textparser/textparser.go
@@ -1,0 +1,29 @@
+package textparser
+
+import (
+	"fmt"
+
+	"github.com/satyrius/gonx"
+)
+
+// TextParser parses variables patterns using config.NamespaceConfig.Format.
+type TextParser struct {
+	parser *gonx.Parser
+}
+
+// NewTextParser returns a new text parser.
+func NewTextParser(format string) *TextParser {
+	return &TextParser{
+		parser: gonx.NewParser(format),
+	}
+}
+
+// ParseString implements the Parser interface.
+func (t *TextParser) ParseString(line string) (map[string]string, error) {
+	entry, err := t.parser.ParseString(line)
+	if err != nil {
+		return nil, fmt.Errorf("text log parsing err: %w", err)
+	}
+
+	return entry.Fields(), nil
+}

--- a/parser/textparser/textparser_test.go
+++ b/parser/textparser/textparser_test.go
@@ -1,0 +1,43 @@
+package textparser
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestTextParse(t *testing.T) {
+	parser := NewTextParser(`[$time_local] $request_method "$request" $request_length $body_bytes_sent $status $request_time $upstream_response_time`)
+	line := `[03/Feb/2021:09:58:57 +0800] GET "GET /gateway/worksheet/worksheet/getWorksheetById?id=16523 HTTP/1.1" 123 519 200 0.544 0.543`
+	got, err := parser.ParseString(line)
+	if err != nil {
+		t.Error(err)
+	}
+	want := map[string]string{
+		"time_local":             "03/Feb/2021:09:58:57 +0800",
+		"request_time":           "0.544",
+		"request_length":         "123",
+		"upstream_response_time": "0.543",
+		"status":                 "200",
+		"body_bytes_sent":        "519",
+		"request":                "GET /gateway/worksheet/worksheet/getWorksheetById?id=16523 HTTP/1.1",
+		"request_method":         "GET",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("TextParser.Parse() = %v, want %v", got, want)
+	}
+}
+
+func BenchmarkParseText(b *testing.B) {
+	parser := NewTextParser(`[$time_local] $request_method "$request" $request_length $body_bytes_sent $status $request_time $upstream_response_time`)
+	line := `[03/Feb/2021:09:58:57 +0800] GET "GET /gateway/worksheet/worksheet/getWorksheetById?id=16523 HTTP/1.1" 123 519 200 0.544 0.543`
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		res, err := parser.ParseString(line)
+		if err != nil {
+			b.Error(err)
+		}
+		_ = fmt.Sprintf("%v", res)
+	}
+}


### PR DESCRIPTION
[FEATURE] Add JSON parser to support JSON log files
Fixes: [#793](https://github.com/martin-helmich/prometheus-nginxlog-exporter/issues/93)

I've made various changes:
1. Bump the Go version to 1.15
2. Add a new flag argument "-parser"
3. Abstract a generic `Parser` interface
4. Provide two implementations of `Parser` interface: plain text parser `TestParser` and JSON parser `JsonParser`

Very welcome to propose improvements to the code.