### PR TITLE
Add CLI flag to verify config and exit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,6 +44,13 @@ Use the configuration file:
 $ ./prometheus-nginxlog-exporter -config-file /path/to/config.hcl
 ----
 
+You can verify your config file before deployment, which will exit with shell status indicating success:
+
+[source]
+----
+$ ./prometheus-nginxlog-exporter -config-file /path/to/config.hcl -verify-config
+----
+
 Installation
 ------------
 
@@ -526,7 +533,7 @@ If your regular expression contains groups, you can also use the matched values 
 relabel "request_uri" {
   from = "request"
   split = 2
-  
+
   match "^/(users|profiles)/[0-9]+" {
     replacement = "/$1/:id"
   }

--- a/config/structs.go
+++ b/config/structs.go
@@ -11,6 +11,7 @@ type StartupFlags struct {
 	ListenPort                 int
 	EnableExperimentalFeatures bool
 	MetricsEndpoint            string
+	VerifyConfig               bool
 
 	CPUProfile string
 	MemProfile string

--- a/main.go
+++ b/main.go
@@ -188,6 +188,7 @@ func main() {
 	flag.StringVar(&opts.CPUProfile, "cpuprofile", "", "write cpu profile to `file`")
 	flag.StringVar(&opts.MemProfile, "memprofile", "", "write memory profile to `file`")
 	flag.StringVar(&opts.MetricsEndpoint, "metrics-endpoint", cfg.Listen.MetricsEndpoint, "URL path at which to serve metrics")
+	flag.BoolVar(&opts.VerifyConfig, "verify-config", false, "Enable this flag to check config file loads, then exit")
 	flag.Parse()
 
 	opts.Filenames = flag.Args()
@@ -265,6 +266,10 @@ func loadConfig(opts *config.StartupFlags, cfg *config.Config) {
 		}
 	} else if err := config.LoadConfigFromFlags(cfg, opts); err != nil {
 		panic(err)
+	}
+	if opts.VerifyConfig {
+		fmt.Printf("Configuration is valid")
+		os.Exit(0)
 	}
 }
 


### PR DESCRIPTION
This change adds a CLI flag to verify the config file/options load successfully, then exit. This allows verification of config files in CICD, where the app needs to gracefully exit or can't easily run in a managed way. 

Output on valid config:
```
 $ ./prometheus-nginxlog-exporter -config-file example-config.hcl -verify-config true
loading configuration file example-config.hcl
Configuration is valid
```