### PR TITLE
Update README.adoc - fix the typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -566,7 +566,7 @@ main_access.log
 main_error.log
 virtualhost1_access.log
 virtualhost1_error.log
-````
+```
 
 The list of files monitored by this namespace will be `/var/log/nginx/main_access.log,/var/log/nginx/virtualhost1_access.log`.
 


### PR DESCRIPTION
Hi!  I'm an devops engineer looking at your documents! 
I don't mean to saw the simple typo in your README... so i pray fix the typo!

```bash
main_access.log
main_error.log
virtualhost1_access.log
virtualhost1_error.log
```` <---
