### PR TITLE
Fix git clone link in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -210,7 +210,7 @@ To build the exporter from source, simply build it with `go get`:
 
 Alternatively, clone this repository and just run `go build`:
 
-    $ git clone git://github.com/martin-helmich/prometheus-nginxlog-exporter
+    $ git clone https://github.com/martin-helmich/prometheus-nginxlog-exporter.git
     $ cd prometheus-nginxlog-exporter
     $ go build
 


### PR DESCRIPTION
`$ git clone git://github.com/martin-helmich/prometheus-nginxlog-exporter`
no longer works as:
```
The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
Change to https git clone link