### PR TITLE
Fix upstream_response_time parsing with colon in value

### DIFF
--- a/main.go
+++ b/main.go
@@ -331,7 +331,7 @@ func floatFromFieldsMulti(fields map[string]string, name string) (float64, bool,
 
 	sum := float64(0)
 
-	for _, v := range strings.Split(val, ",") {
+	for _, v := range strings.FieldsFunc(val, func(r rune) bool { return r == ',' || r == ':' }) {
 		v = strings.TrimSpace(v)
 
 		if v == "-" {


### PR DESCRIPTION
The fix for correct parsing of multiple values in upstream_response_time
applied in #221 was only partial, as it accounts only for commas, but
the value can also contain colons as separators, when the request goes
through an internal redirect.

See the description for '$upstream_addr' in
https://nginx.org/en/docs/http/ngx_http_upstream_module.html for more
info.