### PR TITLE
Fix labels being replaced with empty value when no matches match

### DIFF
--- a/pkg/relabeling/mapping.go
+++ b/pkg/relabeling/mapping.go
@@ -31,14 +31,12 @@ func (r *Relabeling) Map(sourceValue string) (string, error) {
 	}
 
 	if len(r.Matches) > 0 {
-		replacement := ""
 		for i := range r.Matches {
 			if r.Matches[i].CompiledRegexp.MatchString(sourceValue) {
-				replacement = r.Matches[i].CompiledRegexp.ReplaceAllString(sourceValue, r.Matches[i].Replacement)
+				sourceValue = r.Matches[i].CompiledRegexp.ReplaceAllString(sourceValue, r.Matches[i].Replacement)
 				break
 			}
 		}
-		sourceValue = replacement
 	}
 
 	return sourceValue, nil


### PR DESCRIPTION
When use the matches section, then all label value is empty
    relabel_configs:
    - target_label: uri
      from: request_uri
      split: 1
      separator: "?"
      matches:
      - regexp: '^/user/.*'
        replacement: "/user/:id"

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/7465355/200007433-26d6229e-fbbd-45fc-a82d-8dc4622d3670.png">
