### PR TITLE
fix blank replacement on relabel matches fixes #363

### DIFF
--- a/pkg/relabeling/mapping.go
+++ b/pkg/relabeling/mapping.go
@@ -38,7 +38,9 @@ func (r *Relabeling) Map(sourceValue string) (string, error) {
 				break
 			}
 		}
-		sourceValue = replacement
+		if replacement != "" {
+			sourceValue = replacement
+		}
 	}
 
 	return sourceValue, nil


### PR DESCRIPTION
This will fix the relabeling issues reported here #363 and here #377 

```
if len(r.Matches) > 0 {
	replacement := ""
	for i := range r.Matches {
		if r.Matches[i].CompiledRegexp.MatchString(sourceValue) {
			replacement = r.Matches[i].CompiledRegexp.ReplaceAllString(sourceValue, r.Matches[i].Replacement)
			break
		}
	}
	sourceValue = replacement
}
```
The current logic is flawed, because in the case where there are Matches but the Regexp does NOT match the sourceValue
the sourceValue still gets replaced with ""
