### PR TITLE
Fix nil pointer dereference on server shutdown

### DIFF
--- a/pkg/syslog/syslog.go
+++ b/pkg/syslog/syslog.go
@@ -80,7 +80,11 @@ func Listen(conn string, formatSpec string) (syslog.LogPartsChannel, *syslog.Ser
 			return fmt.Errorf("failed to kill syslog server: %w", err)
 		}
 
-		return closeListener()
+		if closeListener != nil {
+			return closeListener()
+		}
+
+		return nil
 	}
 
 	return channel, server, stopFn, nil


### PR DESCRIPTION
```
2024-12-24T16:26:05.629+0300        info        prometheus-nginxlog-exporter/main.go:101        caught term terminated. exiting
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x881f0e]
goroutine 51 [running]:
github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/syslog.Listen.func1()
        /home/runner/work/prometheus-nginxlog-exporter/prometheus-nginxlog-exporter/pkg/syslog/syslog.go:83 +0x6e
main.processNamespace.func2()
        /home/runner/work/prometheus-nginxlog-exporter/prometheus-nginxlog-exporter/main.go:233 +0x3f
created by main.processNamespace
        /home/runner/work/prometheus-nginxlog-exporter/prometheus-nginxlog-exporter/main.go:230 +0x23b
```