### PR TITLE
chore: fixing CVE-2024-24790

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.21.11
 
       - name: Compile
         run: CGO_ENABLED=0 go build -a -installsuffix cgo -o prometheus-nginxlog-exporter .
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.21.11
 
       - name: Run unit tests
         run: go test ./...
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.21.11
 
       - name: Validate Goreleaser config
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.21.11
           
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21.11
 
 COPY . /work
 WORKDIR /work

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/martin-helmich/prometheus-nginxlog-exporter
 
-go 1.20
+go 1.21
 
 require (
 	github.com/hashicorp/consul/api v1.26.1


### PR DESCRIPTION
## Context

Our internal security scan systems are detecting the CVE-2024-24790 on nginxlog-exporter. This is a vulnerability present in go 1.20 and its only fixed on 1.21.11 and 1.22.4 onwards. Pinning the workflows to use 1.21.11 so it picks the current build version since go.mod does not enforce a min version.

All the local tests and the CI tests are passing.

## Proof of Work

```
go version go1.21.11 darwin/arm64
--- go build . ---
OK
--- CGO_ENABLED=0 go build (CI-style) ---
OK
--- go test ./... -count=1 (CGO_ENABLED=0, matches CI) ---
?   	github.com/martin-helmich/prometheus-nginxlog-exporter	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/log	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/discovery	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/metrics	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/parser	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/prof	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/syslog	[no test files]
?   	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/tail	[no test files]
ok  	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/config	0.288s
ok  	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/parser/jsonparser	0.679s
ok  	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/parser/textparser	0.881s
ok  	github.com/martin-helmich/prometheus-nginxlog-exporter/pkg/relabeling	0.477s

$ CGO_ENABLED=0 go build -a -installsuffix cgo -o prometheus-nginxlog-exporter . && chmod +x ./prometheus-nginxlog-exporter && /tmp/nginxlog-behave-venv/bin/behave
[... 11 features, 34 scenarios ...]
11 features passed, 0 failed, 0 skipped
34 scenarios passed, 0 failed, 0 skipped
135 steps passed, 0 failed, 0 skipped
Took 0min 38.243s
```